### PR TITLE
Broke down the Response CREATED status with Location Header checks

### DIFF
--- a/src/Ogooreck.Sample.Api.Tests/ApiTests.cs
+++ b/src/Ogooreck.Sample.Api.Tests/ApiTests.cs
@@ -29,7 +29,7 @@ public class Tests: IClassFixture<ApiSpecification<Program>>
                 BODY(new RegisterProductRequest("abc-123", "Ogooreck"))
             )
             .When(POST)
-            .Then(CREATED);
+            .Then(CREATED, RESPONSE_LOCATION_HEADER());
 
     #endregion ApiPostSample
 }

--- a/src/Ogooreck/Ogooreck.csproj
+++ b/src/Ogooreck/Ogooreck.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <VersionPrefix>0.1.1</VersionPrefix>
+        <VersionPrefix>0.1.2</VersionPrefix>
         <TargetFramework>net6.0</TargetFramework>
         <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>


### PR DESCRIPTION
Broke down the CREATED status with Location Header checks to give the possibility of providing a custom header easier.

Added also RESPONSE_HEADERS helper and aligned response headers check with it.