### PR TITLE
Fixed testing events for union types

### DIFF
--- a/.github/workflows/build.dotnet.yml
+++ b/.github/workflows/build.dotnet.yml
@@ -15,14 +15,19 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Install .NET 6
-              uses: actions/setup-dotnet@v3
+              uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: "6.0.x"
 
             - name: Install .NET 7
-              uses: actions/setup-dotnet@v3
+              uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: "7.0.x"
 
-            - name: Restore NuGet packages
+            - name: Install .NET 8
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: "8.0.x"
+
+            - name: Build and Test
               run: ./build.sh test

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -6,7 +6,7 @@ env:
     config: Release
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-    dotnet_core_version: 7.0.x
+    dotnet_core_version: 8.0.x
 
 jobs:
     publish_job:
@@ -14,10 +14,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install .NET
-              uses: actions/setup-dotnet@v3
+              uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: ${{ env.dotnet_core_version }}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Github Actions](https://github.com/oskardudycz/Ogooreck/actions/workflows/build.dotnet.yml/badge.svg?branch=main) [![blog](https://img.shields.io/badge/blog-event--driven.io-brightgreen)](https://event-driven.io/?utm_source=event_sourcing_net) [![blog](https://img.shields.io/badge/%F0%9F%9A%80-Architecture%20Weekly-important)](https://www.architecture-weekly.com/?utm_source=event_sourcing_net)
+[![Twitter Follow](https://img.shields.io/twitter/follow/oskar_at_net?style=social)](https://twitter.com/oskar_at_net) ![Github Actions](https://github.com/oskardudycz/Ogooreck/actions/workflows/build.dotnet.yml/badge.svg?branch=main) [![blog](https://img.shields.io/badge/blog-event--driven.io-brightgreen)](https://event-driven.io/?utm_source=event_sourcing_net) [![blog](https://img.shields.io/badge/%F0%9F%9A%80-Architecture%20Weekly-important)](https://www.architecture-weekly.com/?utm_source=event_sourcing_net)
 [![Nuget Package](https://badgen.net/nuget/v/ogooreck)](https://www.nuget.org/packages/Ogooreck/)
-[![Nuget](https://img.shields.io/nuget/dt/ogooreck)](https://www.nuget.org/packages/Ogooreck/) [![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/oskardudycz/) 
+[![Nuget](https://img.shields.io/nuget/dt/ogooreck)](https://www.nuget.org/packages/Ogooreck/)
 
 # 🥒 Ogooreck
 

--- a/build.sh
+++ b/build.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 version="$(dotnet --version)"
-if [[ $version = 7.* ]]; then
-  target_framework="net7.0"
+if [[ $version = 8.* ]]; then
+  target_framework="net8.0"
 else
-  echo "BUILD FAILURE: .NET 7 SDK required to run build"
+  echo "BUILD FAILURE: .NET 8 SDK required to run build"
   exit 1
 fi
 

--- a/src/Ogooreck.Build/Ogooreck.Build.csproj
+++ b/src/Ogooreck.Build/Ogooreck.Build.csproj
@@ -2,13 +2,13 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bullseye" Version="4.2.0" />
-        <PackageReference Include="SimpleExec" Version="11.0.0" />
+        <PackageReference Include="Bullseye" Version="5.0.0" />
+        <PackageReference Include="SimpleExec" Version="12.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Ogooreck.Build/Program.cs
+++ b/src/Ogooreck.Build/Program.cs
@@ -1,7 +1,7 @@
 ﻿using static Bullseye.Targets;
 using static SimpleExec.Command;
 
-const string framework = "net7.0";
+const string framework = "net8.0";
 const string configuration = "Release";
 
 Target("default", DependsOn("compile"));

--- a/src/Ogooreck.Sample.Api.Tests/Ogooreck.Sample.Api.Tests.csproj
+++ b/src/Ogooreck.Sample.Api.Tests/Ogooreck.Sample.Api.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.11.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.9" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="xunit" Version="2.8.0" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.4" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -22,7 +22,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.1">
+        <PackageReference Include="MarkdownSnippets.MsBuild" Version="27.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/Ogooreck.Sample.Api/Ogooreck.Sample.Api.csproj
+++ b/src/Ogooreck.Sample.Api/Ogooreck.Sample.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Ogooreck.Sample.BusinessLogic.FSharp.Tests/Deciders/BankAccount.fs
+++ b/src/Ogooreck.Sample.BusinessLogic.FSharp.Tests/Deciders/BankAccount.fs
@@ -47,7 +47,7 @@ type BankAccount =
 
 let evolve bankAccount bankAccountEvent : BankAccount =
     match bankAccount, bankAccountEvent with
-    | Initial _, BankAccountOpened event ->
+    | Initial, BankAccountOpened event ->
         Open
             {| Id = event.BankAccountId
                Balance = 0M

--- a/src/Ogooreck.Sample.BusinessLogic.FSharp.Tests/Deciders/BankAccountDecider.fs
+++ b/src/Ogooreck.Sample.BusinessLogic.FSharp.Tests/Deciders/BankAccountDecider.fs
@@ -33,7 +33,7 @@ let openBankAccount (command: OpenBankAccount) bankAccount : Event =
     match bankAccount with
     | Open _ -> invalidOp "Account is already opened!"
     | Closed _ -> invalidOp "Account is already closed!"
-    | Initial _ ->
+    | Initial ->
         BankAccountOpened
             { BankAccountId = command.BankAccountId
               AccountNumber = command.AccountNumber
@@ -44,7 +44,7 @@ let openBankAccount (command: OpenBankAccount) bankAccount : Event =
 
 let recordDeposit (command: RecordDeposit) bankAccount : Event =
     match bankAccount with
-    | Initial _ -> invalidOp "Account is not opened!"
+    | Initial -> invalidOp "Account is not opened!"
     | Closed _ -> invalidOp "Account is closed!"
     | Open state ->
         DepositRecorded
@@ -56,7 +56,7 @@ let recordDeposit (command: RecordDeposit) bankAccount : Event =
 
 let withdrawCashFromAtm (command: WithdrawCashFromAtm) bankAccount : Event =
     match bankAccount with
-    | Initial _ -> invalidOp "Account is not opened!"
+    | Initial -> invalidOp "Account is not opened!"
     | Closed _ -> invalidOp "Account is closed!"
     | Open state ->
         if (state.Balance < command.Amount) then
@@ -71,7 +71,7 @@ let withdrawCashFromAtm (command: WithdrawCashFromAtm) bankAccount : Event =
 
 let closeBankAccount (command: CloseBankAccount) bankAccount : Event =
     match bankAccount with
-    | Initial _ -> invalidOp "Account is not opened!"
+    | Initial -> invalidOp "Account is not opened!"
     | Closed _ -> invalidOp "Account is already closed!"
     | Open state ->
         BankAccountClosed

--- a/src/Ogooreck.Sample.BusinessLogic.FSharp.Tests/Ogooreck.Sample.BusinessLogic.FSharp.Tests.fsproj
+++ b/src/Ogooreck.Sample.BusinessLogic.FSharp.Tests/Ogooreck.Sample.BusinessLogic.FSharp.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -15,17 +15,17 @@
         <PackageReference Include="FsCheck" Version="2.16.6" />
         <PackageReference Include="FsCheck.Xunit" Version="2.16.6" />
         <PackageReference Include="FSharp.UMX" Version="1.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="xunit" Version="2.8.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Update="FSharp.Core" Version="7.0.300" />
+        <PackageReference Update="FSharp.Core" Version="8.0.200" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Ogooreck.Sample.BusinessLogic.Tests/Functions/EventSourcedWithUnionType/Incident.cs
+++ b/src/Ogooreck.Sample.BusinessLogic.Tests/Functions/EventSourcedWithUnionType/Incident.cs
@@ -1,0 +1,170 @@
+namespace Ogooreck.Sample.BusinessLogic.Tests.Functions.EventSourcedWithUnionType;
+using static IncidentEvent;
+
+public abstract record IncidentEvent
+{
+    public record IncidentLogged(
+        Guid IncidentId,
+        Guid CustomerId,
+        Contact Contact,
+        string Description,
+        Guid LoggedBy,
+        DateTimeOffset LoggedAt
+    ): IncidentEvent;
+
+    public record IncidentCategorised(
+        Guid IncidentId,
+        IncidentCategory Category,
+        Guid CategorisedBy,
+        DateTimeOffset CategorisedAt
+    ): IncidentEvent;
+
+    public record IncidentPrioritised(
+        Guid IncidentId,
+        IncidentPriority Priority,
+        Guid PrioritisedBy,
+        DateTimeOffset PrioritisedAt
+    ): IncidentEvent;
+
+    public record AgentAssignedToIncident(
+        Guid IncidentId,
+        Guid AgentId,
+        DateTimeOffset AssignedAt
+    ): IncidentEvent;
+
+    public record AgentRespondedToIncident(
+        Guid IncidentId,
+        IncidentResponse.FromAgent Response,
+        DateTimeOffset RespondedAt
+    ): IncidentEvent;
+
+    public record CustomerRespondedToIncident(
+        Guid IncidentId,
+        IncidentResponse.FromCustomer Response,
+        DateTimeOffset RespondedAt
+    ): IncidentEvent;
+
+    public record IncidentResolved(
+        Guid IncidentId,
+        ResolutionType Resolution,
+        Guid ResolvedBy,
+        DateTimeOffset ResolvedAt
+    ): IncidentEvent;
+
+    public record ResolutionAcknowledgedByCustomer(
+        Guid IncidentId,
+        Guid AcknowledgedBy,
+        DateTimeOffset AcknowledgedAt
+    ): IncidentEvent;
+
+    public record IncidentClosed(
+        Guid IncidentId,
+        Guid ClosedBy,
+        DateTimeOffset ClosedAt
+    ): IncidentEvent;
+
+    private IncidentEvent() { }
+}
+
+public enum IncidentStatus
+{
+    Pending = 1,
+    Resolved = 8,
+    ResolutionAcknowledgedByCustomer = 16,
+    Closed = 32
+}
+
+public record Incident(
+    Guid Id,
+    IncidentStatus Status = IncidentStatus.Pending,
+    bool HasOutstandingResponseToCustomer = false,
+    IncidentCategory? Category = null,
+    IncidentPriority? Priority = null,
+    Guid? AgentId = null,
+    int Version = 1
+)
+{
+    public static Incident Create(IncidentLogged logged) =>
+        new(logged.IncidentId);
+
+    public Incident Apply(IncidentCategorised categorised) =>
+        this with { Category = categorised.Category };
+
+    public Incident Apply(IncidentPrioritised prioritised) =>
+        this with { Priority = prioritised.Priority };
+
+    public Incident Apply(AgentRespondedToIncident agentResponded) =>
+        this with { HasOutstandingResponseToCustomer = false };
+
+    public Incident Apply(CustomerRespondedToIncident customerResponded) =>
+        this with { HasOutstandingResponseToCustomer = true };
+
+    public Incident Apply(IncidentResolved resolved) =>
+        this with { Status = IncidentStatus.Resolved };
+
+    public Incident Apply(ResolutionAcknowledgedByCustomer acknowledged) =>
+        this with { Status = IncidentStatus.ResolutionAcknowledgedByCustomer };
+
+    public Incident Apply(IncidentClosed closed) =>
+        this with { Status = IncidentStatus.Closed };
+}
+
+public enum IncidentCategory
+{
+    Software,
+    Hardware,
+    Network,
+    Database
+}
+
+public enum IncidentPriority
+{
+    Critical,
+    High,
+    Medium,
+    Low
+}
+
+public enum ResolutionType
+{
+    Temporary,
+    Permanent,
+    NotAnIncident
+}
+
+public enum ContactChannel
+{
+    Email,
+    Phone,
+    InPerson,
+    GeneratedBySystem
+}
+
+public record Contact(
+    ContactChannel ContactChannel,
+    string? FirstName = null,
+    string? LastName = null,
+    string? EmailAddress = null,
+    string? PhoneNumber = null
+);
+
+public abstract record IncidentResponse
+{
+    public record FromAgent(
+        Guid AgentId,
+        string Content,
+        bool VisibleToCustomer
+    ): IncidentResponse(Content);
+
+    public record FromCustomer(
+        Guid CustomerId,
+        string Content
+    ): IncidentResponse(Content);
+
+    public string Content { get; init; }
+
+    private IncidentResponse(string content)
+    {
+        Content = content;
+    }
+}

--- a/src/Ogooreck.Sample.BusinessLogic.Tests/Functions/EventSourcedWithUnionType/IncidentService.cs
+++ b/src/Ogooreck.Sample.BusinessLogic.Tests/Functions/EventSourcedWithUnionType/IncidentService.cs
@@ -1,0 +1,176 @@
+namespace Ogooreck.Sample.BusinessLogic.Tests.Functions.EventSourcedWithUnionType;
+using static IncidentEvent;
+using static IncidentCommand;
+
+public record IncidentCommand
+{
+    public record LogIncident(
+        Guid IncidentId,
+        Guid CustomerId,
+        Contact Contact,
+        string Description,
+        Guid LoggedBy
+    ): IncidentCommand;
+
+    public record CategoriseIncident(
+        Guid IncidentId,
+        IncidentCategory Category,
+        Guid CategorisedBy
+    ): IncidentCommand;
+
+    public record PrioritiseIncident(
+        Guid IncidentId,
+        IncidentPriority Priority,
+        Guid PrioritisedBy
+    ): IncidentCommand;
+
+    public record AssignAgentToIncident(
+        Guid IncidentId,
+        Guid AgentId
+    ): IncidentCommand;
+
+    public record RecordAgentResponseToIncident(
+        Guid IncidentId,
+        IncidentResponse.FromAgent Response
+    ): IncidentCommand;
+
+    public record RecordCustomerResponseToIncident(
+        Guid IncidentId,
+        IncidentResponse.FromCustomer Response
+    ): IncidentCommand;
+
+    public record ResolveIncident(
+        Guid IncidentId,
+        ResolutionType Resolution,
+        Guid ResolvedBy
+    ): IncidentCommand;
+
+    public record AcknowledgeResolution(
+        Guid IncidentId,
+        Guid AcknowledgedBy
+    ): IncidentCommand;
+
+    public record CloseIncident(
+        Guid IncidentId,
+        Guid ClosedBy
+    ): IncidentCommand;
+
+    private IncidentCommand() { }
+}
+
+internal static class IncidentService
+{
+    public static IncidentLogged Handle(Func<DateTimeOffset> now, LogIncident command)
+    {
+        var (incidentId, customerId, contact, description, loggedBy) = command;
+
+        return new IncidentLogged(incidentId, customerId, contact, description, loggedBy, now());
+    }
+
+    public static IncidentCategorised Handle(Func<DateTimeOffset> now, Incident current, CategoriseIncident command)
+    {
+        if (current.Status == IncidentStatus.Closed)
+            throw new InvalidOperationException("Incident is already closed");
+
+        var (incidentId, incidentCategory, categorisedBy) = command;
+
+        return new IncidentCategorised(incidentId, incidentCategory, categorisedBy, now());
+    }
+
+    public static IncidentPrioritised Handle(Func<DateTimeOffset> now, Incident current, PrioritiseIncident command)
+    {
+        if (current.Status == IncidentStatus.Closed)
+            throw new InvalidOperationException("Incident is already closed");
+
+        var (incidentId, incidentPriority, prioritisedBy) = command;
+
+        return new IncidentPrioritised(incidentId, incidentPriority, prioritisedBy, now());
+    }
+
+    public static AgentAssignedToIncident Handle(Func<DateTimeOffset> now, Incident current,
+        AssignAgentToIncident command)
+    {
+        if (current.Status == IncidentStatus.Closed)
+            throw new InvalidOperationException("Incident is already closed");
+
+        var (incidentId, agentId) = command;
+
+        return new AgentAssignedToIncident(incidentId, agentId, now());
+    }
+
+    public static AgentRespondedToIncident Handle(
+        Func<DateTimeOffset> now,
+        Incident current,
+        RecordAgentResponseToIncident command
+    )
+    {
+        if (current.Status == IncidentStatus.Closed)
+            throw new InvalidOperationException("Incident is already closed");
+
+        var (incidentId, response) = command;
+
+        return new AgentRespondedToIncident(incidentId, response, now());
+    }
+
+    public static CustomerRespondedToIncident Handle(
+        Func<DateTimeOffset> now,
+        Incident current,
+        RecordCustomerResponseToIncident command
+    )
+    {
+        if (current.Status == IncidentStatus.Closed)
+            throw new InvalidOperationException("Incident is already closed");
+
+        var (incidentId, response) = command;
+
+        return new CustomerRespondedToIncident(incidentId, response, now());
+    }
+
+    public static IncidentResolved Handle(
+        Func<DateTimeOffset> now,
+        Incident current,
+        ResolveIncident command
+    )
+    {
+        if (current.Status is IncidentStatus.Resolved or IncidentStatus.Closed)
+            throw new InvalidOperationException("Cannot resolve already resolved or closed incident");
+
+        if (current.HasOutstandingResponseToCustomer)
+            throw new InvalidOperationException("Cannot resolve incident that has outstanding responses to customer");
+
+        var (incidentId, resolution, resolvedBy) = command;
+
+        return new IncidentResolved(incidentId, resolution, resolvedBy, now());
+    }
+
+    public static ResolutionAcknowledgedByCustomer Handle(
+        Func<DateTimeOffset> now,
+        Incident current,
+        AcknowledgeResolution command
+    )
+    {
+        if (current.Status is not IncidentStatus.Resolved)
+            throw new InvalidOperationException("Only resolved incident can be acknowledged");
+
+        var (incidentId, acknowledgedBy) = command;
+
+        return new ResolutionAcknowledgedByCustomer(incidentId, acknowledgedBy, now());
+    }
+
+    public static IncidentClosed Handle(
+        Func<DateTimeOffset> now,
+        Incident current,
+        CloseIncident command
+    )
+    {
+        if (current.Status is not IncidentStatus.ResolutionAcknowledgedByCustomer)
+            throw new InvalidOperationException("Only incident with acknowledged resolution can be closed");
+
+        if (current.HasOutstandingResponseToCustomer)
+            throw new InvalidOperationException("Cannot close incident that has outstanding responses to customer");
+
+        var (incidentId, acknowledgedBy) = command;
+
+        return new IncidentClosed(incidentId, acknowledgedBy, now());
+    }
+}

--- a/src/Ogooreck.Sample.BusinessLogic.Tests/Functions/EventSourcedWithUnionType/IncidentTests.cs
+++ b/src/Ogooreck.Sample.BusinessLogic.Tests/Functions/EventSourcedWithUnionType/IncidentTests.cs
@@ -1,0 +1,73 @@
+﻿using Ogooreck.BusinessLogic;
+
+namespace Ogooreck.Sample.BusinessLogic.Tests.Functions.EventSourcedWithUnionType;
+
+using static IncidentEventsBuilder;
+using static IncidentService;
+using static IncidentEvent;
+using static IncidentCommand;
+
+public class IncidentTests
+{
+    private static readonly DateTimeOffset now = DateTimeOffset.UtcNow;
+
+    private static readonly Func<Incident, IncidentEvent, Incident> evolve =
+        (incident, @event) =>
+        {
+            return @event switch
+            {
+                IncidentLogged logged => Incident.Create(logged),
+                IncidentCategorised categorised => incident.Apply(categorised),
+                IncidentPrioritised prioritised => incident.Apply(prioritised),
+                AgentRespondedToIncident agentResponded => incident.Apply(agentResponded),
+                CustomerRespondedToIncident customerResponded => incident.Apply(customerResponded),
+                IncidentResolved resolved => incident.Apply(resolved),
+                ResolutionAcknowledgedByCustomer acknowledged => incident.Apply(acknowledged),
+                IncidentClosed closed => incident.Apply(closed),
+                _ => incident
+            };
+        };
+
+    private readonly HandlerSpecification<IncidentEvent, Incident> Spec =
+        Specification.For<IncidentEvent, Incident>(evolve);
+
+    [Fact]
+    public void GivenNonExistingIncident_WhenOpenWithValidParams_ThenSucceeds()
+    {
+        var incidentId = Guid.NewGuid();
+        var customerId = Guid.NewGuid();
+        var contact = new Contact(ContactChannel.Email, EmailAddress: "john@doe.com");
+        var description = Guid.NewGuid().ToString();
+        var loggedBy = Guid.NewGuid();
+
+        Spec.Given()
+            .When(() => Handle(() => now, new LogIncident(incidentId, customerId, contact, description, loggedBy)))
+            .Then(new IncidentLogged(incidentId, customerId, contact, description, loggedBy, now));
+    }
+
+    [Fact]
+    public void GivenOpenIncident_WhenCategoriseWithValidParams_ThenSucceeds()
+    {
+        var incidentId = Guid.NewGuid();
+
+        var category = IncidentCategory.Database;
+        var categorisedBy = Guid.NewGuid();
+
+        Spec.Given(IncidentLogged(incidentId, now))
+            .When(incident => Handle(() => now, incident, new CategoriseIncident(incidentId, category, categorisedBy)))
+            .Then(new IncidentCategorised(incidentId, category, categorisedBy, now));
+    }
+}
+
+public static class IncidentEventsBuilder
+{
+    public static IncidentLogged IncidentLogged(Guid incidentId, DateTimeOffset now)
+    {
+        var customerId = Guid.NewGuid();
+        var contact = new Contact(ContactChannel.Email, EmailAddress: "john@doe.com");
+        var description = Guid.NewGuid().ToString();
+        var loggedBy = Guid.NewGuid();
+
+        return new IncidentLogged(incidentId, customerId, contact, description, loggedBy, now);
+    }
+}

--- a/src/Ogooreck.Sample.BusinessLogic.Tests/Ogooreck.Sample.BusinessLogic.Tests.csproj
+++ b/src/Ogooreck.Sample.BusinessLogic.Tests/Ogooreck.Sample.BusinessLogic.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -9,13 +9,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="xunit" Version="2.8.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Ogooreck/BusinessLogic/DeciderSpecification.cs
+++ b/src/Ogooreck/BusinessLogic/DeciderSpecification.cs
@@ -80,14 +80,14 @@ public class ThenDeciderSpecificationBuilder<TEvent, TState>
     public ThenDeciderSpecificationBuilder<TEvent, TState> Then(params TEvent[] expectedEvents)
     {
         var result = getResult.Value;
-        result.NewEvents.Should().BeEquivalentTo(expectedEvents);
+        result.NewEvents.Cast<object>().Should().BeEquivalentTo(expectedEvents.Cast<object>(), "Expected events don't match the result");
         return this;
     }
 
     public ThenDeciderSpecificationBuilder<TEvent, TState> Then(TState expectedState)
     {
         var result = getResult.Value;
-        result.CurrentState.Should().BeEquivalentTo(expectedState);
+        result.CurrentState.Should().BeEquivalentTo(expectedState, "Expected events don't match the result");
         return this;
     }
 

--- a/src/Ogooreck/Factories/ObjectFactory.cs
+++ b/src/Ogooreck/Factories/ObjectFactory.cs
@@ -19,7 +19,9 @@ public static class ObjectFactory<T>
         if (t.HasDefaultConstructor())
             return Expression.Lambda<Func<T>>(Expression.New(t)).Compile();
 
+#pragma warning disable SYSLIB0050
         return () => (T)FormatterServices.GetUninitializedObject(t);
+#pragma warning restore SYSLIB0050
     }
 }
 

--- a/src/Ogooreck/Ogooreck.csproj
+++ b/src/Ogooreck/Ogooreck.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <VersionPrefix>0.8.0</VersionPrefix>
+        <VersionPrefix>0.8.1</VersionPrefix>
         <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>

--- a/src/Ogooreck/Ogooreck.csproj
+++ b/src/Ogooreck/Ogooreck.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <VersionPrefix>0.8.1</VersionPrefix>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>
         <GenerateAssemblyProductAttribute>true</GenerateAssemblyProductAttribute>
@@ -11,7 +11,7 @@
         <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <LangVersion>11.0</LangVersion>
+        <LangVersion>12.0</LangVersion>
         <Authors>Oskar Dudycz</Authors>
 <!--        <PackageIconUrl>https://github.com/oskardudycz/Ogooreck/content/images/emblem.png</PackageIconUrl>-->
         <PackageProjectUrl>https://github.com/oskardudycz/Ogooreck</PackageProjectUrl>
@@ -26,16 +26,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.11.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.20" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.29" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.18" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
FluentAssertion BeEquivalentTo cannot work for type collection. Casted elements to objects to run automatic type selection

Bumped also to .NET 8.