### PR TITLE
Made WebApplicationFactory disposal silent

### DIFF
--- a/src/Ogooreck/API/ApiSpecification.cs
+++ b/src/Ogooreck/API/ApiSpecification.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 #pragma warning disable CS1591
 
@@ -25,6 +27,10 @@ public class ApiSpecification<TProgram>: IDisposable where TProgram : class
 
     public static ApiSpecification<TProgram> Setup(WebApplicationFactory<TProgram> applicationFactory) =>
         new(applicationFactory);
+
+    public static ApiSpecification<TProgram> With(ILoggerProvider loggerProvider) =>
+        new(new WebApplicationFactory<TProgram>().WithWebHostBuilder(
+            b => b.ConfigureServices(s => s.AddSingleton(loggerProvider))));
 
     public GivenApiSpecificationBuilder Given(
         params RequestDefinition[] builders
@@ -70,8 +76,17 @@ public class ApiSpecification<TProgram>: IDisposable where TProgram : class
         return response;
     }
 
-    public void Dispose() =>
-        applicationFactory.Dispose();
+    public void Dispose()
+    {
+        try
+        {
+            applicationFactory.Dispose();
+        }
+        catch (Exception exc)
+        {
+            Console.WriteLine($"Error disposing WebApplicationFactory: {exc}");
+        }
+    }
 }
 
 public class TestApiRequest

--- a/src/Ogooreck/Ogooreck.csproj
+++ b/src/Ogooreck/Ogooreck.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <VersionPrefix>0.8.1</VersionPrefix>
+        <VersionPrefix>0.8.2</VersionPrefix>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>


### PR DESCRIPTION
Added silent disposal for the WebApplicationFactory in case there's some dependency (like Marten ProjectCoordinator atm) that sometimes fails during disposal. That should not make tests fail, even though it's not a great thing.

Added possibility to inject ILoggerProvider to enable injecting XUnit test output helper.

Bumped to 0.8.2